### PR TITLE
Add option for combined stdout and stderr.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(process_stdout_argc process_stdout_argc.c)
 add_executable(process_stdout_argv process_stdout_argv.c)
 add_executable(process_stderr_argc process_stderr_argc.c)
 add_executable(process_stderr_argv process_stderr_argv.c)
+add_executable(process_combined_stdout_stderr process_combined_stdout_stderr.c)
 
 add_executable(process_test
   ../process.h

--- a/test/main.c
+++ b/test/main.c
@@ -32,7 +32,7 @@ UTEST(create, process_return_zero) {
   struct process_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -46,7 +46,7 @@ UTEST(create, process_return_fortytwo) {
   struct process_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -56,12 +56,12 @@ UTEST(create, process_return_fortytwo) {
 }
 
 UTEST(create, process_return_argc) {
-  const char *const commandLine[] = {
-      "./process_return_argc", "foo", "bar", "baz", "faz", 0};
+  const char *const commandLine[] = {"./process_return_argc", "foo",
+                                     "bar", "baz", "faz", 0};
   struct process_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -75,7 +75,7 @@ UTEST(create, process_return_argv) {
   struct process_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -90,7 +90,7 @@ UTEST(create, process_return_stdin) {
   int ret = -1;
   FILE *stdin_file;
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   stdin_file = process_stdin(&process);
   ASSERT_TRUE(stdin_file);
@@ -125,7 +125,7 @@ UTEST(create, process_return_stdin_count) {
   FILE *stdin_file;
   const char temp[41] = "Wee, sleekit, cow'rin, tim'rous beastie!";
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   stdin_file = process_stdin(&process);
   ASSERT_TRUE(stdin_file);
@@ -147,7 +147,7 @@ UTEST(create, process_stdout_argc) {
   FILE *stdout_file;
   char temp[32];
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -172,7 +172,7 @@ UTEST(create, process_stdout_argv) {
   char temp[16];
   const char compare[16] = "foo bar baz faz";
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -196,7 +196,7 @@ UTEST(create, process_stderr_argc) {
   FILE *stderr_file;
   char temp[32];
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -221,7 +221,7 @@ UTEST(create, process_stderr_argv) {
   char temp[16];
   const char compare[16] = "foo bar baz faz";
 
-  ASSERT_EQ(0, process_create(commandLine, &process));
+  ASSERT_EQ(0, process_create(commandLine, 0, &process));
 
   ASSERT_EQ(0, process_join(&process, &ret));
 
@@ -233,6 +233,35 @@ UTEST(create, process_stderr_argv) {
   ASSERT_TRUE(fgets(temp, 16, stderr_file));
 
   ASSERT_STREQ(temp, compare);
+
+  ASSERT_EQ(0, process_destroy(&process));
+}
+
+UTEST(create, process_combined_stdout_stderr) {
+  const char *const commandLine[] = {"./process_combined_stdout_stderr", 0};
+  struct process_s process;
+  int ret = -1;
+  FILE *stdout_file;
+  FILE *stderr_file;
+  char temp[25];
+  const char compare[25] = "Hello,It's me!world!Yay!";
+
+  ASSERT_EQ(0, process_create(commandLine,
+                              process_option_combined_stdout_stderr, &process));
+
+  ASSERT_EQ(0, process_join(&process, &ret));
+
+  ASSERT_EQ(0, ret);
+
+  stdout_file = process_stdout(&process);
+  ASSERT_TRUE(stdout_file);
+
+  stderr_file = process_stderr(&process);
+  ASSERT_FALSE(stderr_file);
+
+  ASSERT_TRUE(fgets(temp, 25, stdout_file));
+
+  ASSERT_STREQ(compare, temp);
 
   ASSERT_EQ(0, process_destroy(&process));
 }

--- a/test/process_combined_stdout_stderr.c
+++ b/test/process_combined_stdout_stderr.c
@@ -1,0 +1,38 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org/>
+
+#include <stdio.h>
+
+int main(int argc, const char *const argv[]) {
+  fprintf(stdout, "Hello,");
+  fflush(0);
+  fprintf(stderr, "It's me!");
+  fflush(0);
+  fprintf(stdout, "world!");
+  fflush(0);
+  fprintf(stderr, "Yay!\n");
+  fflush(0);
+  return 0;
+}


### PR DESCRIPTION
Add an option (process_option_combined_stdout_stderr) to make stdout and
stderr use the same FILE object - as was requested in issue #2.

This causes an interface change to process_create, to add an int options
as the second parameter.