### PR TITLE
windows: close child process's pipe handles at join/destroy time

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   )
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set_source_files_properties(test.cpp PROPERTIES
-    COMPILE_FLAGS "-Wall -Wextra -Weverything -Werror -Wpedantic"
+    COMPILE_FLAGS "-Wall -Wextra -Weverything -Werror -Wpedantic -Wno-zero-as-null-pointer-constant"
   )
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(test.cpp PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,7 +59,7 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(main.c test.c PROPERTIES
-    COMPILE_FLAGS "/Wall /WX /wd4514"
+    COMPILE_FLAGS "/Wall /WX /wd4514 /wd5045"
   )
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
@@ -75,7 +75,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   )
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(test.cpp PROPERTIES
-    COMPILE_FLAGS "/Wall /WX /wd4514"
+    COMPILE_FLAGS "/Wall /WX /wd4514 /wd5045"
   )
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")

--- a/test/main.c
+++ b/test/main.c
@@ -185,6 +185,10 @@ UTEST(create, process_stdout_argv) {
 
   ASSERT_STREQ(temp, compare);
 
+  ASSERT_TRUE(fgets(temp, 16, stdout_file)); // should contain trailing newline character(s)
+  ASSERT_FALSE(fgets(temp, 16, stdout_file)); // should be at EOF now
+  ASSERT_TRUE(feof(stdout_file));
+
   ASSERT_EQ(0, process_destroy(&process));
 }
 
@@ -233,6 +237,10 @@ UTEST(create, process_stderr_argv) {
   ASSERT_TRUE(fgets(temp, 16, stderr_file));
 
   ASSERT_STREQ(temp, compare);
+
+  ASSERT_TRUE(fgets(temp, 16, stderr_file)); // should contain trailing newline character(s)
+  ASSERT_FALSE(fgets(temp, 16, stderr_file)); // should be at EOF now
+  ASSERT_TRUE(feof(stderr_file));
 
   ASSERT_EQ(0, process_destroy(&process));
 }


### PR DESCRIPTION
Based on [a Stack Overflow thread](https://stackoverflow.com/questions/10841840/win32-readfile-from-pipe-block-even-after-child-terminated), I think the child process's end of the pipes need to be manually closed when the process ends, in order for the parent's ends to register EOF events. Otherwise, they just hang waiting for more output that can never arrive (as shown in the tests I added).

I *think* my fix here is correct, but I've only tested on Windows.