### PR TITLE
Rename process.h -> subprocess.h and all the functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# 🐜 process.h
+# 🐜 subprocess.h
 
-[![Build status](https://ci.appveyor.com/api/projects/status/0sm37thiavt9juee?svg=true)](https://ci.appveyor.com/project/sheredom/process-h)
-[![Build Status](https://travis-ci.org/sheredom/process.h.svg)](https://travis-ci.org/sheredom/process.h)
+[![Build status](https://ci.appveyor.com/api/projects/status/0sm37thiavt9juee?svg=true)](https://ci.appveyor.com/project/sheredom/subprocess-h)
+[![Build Status](https://travis-ci.org/sheredom/subprocess.h.svg)](https://travis-ci.org/sheredom/process.h)
 
 A simple one header solution to launching processes and interacting with them
 for C/C++.
 
 ## Usage
 
-Just `#include "process.h"` in your code!
+Just `#include "subprocess.h"` in your code!
 
 The current supported compilers are gcc, clang and msvc.
 
@@ -16,18 +16,18 @@ The current supported platforms are Linux, macOS and Windows.
 
 ## Design
 
-Process is a single header cross-platform library that allows users to launch
-processes, interact with the stdin, stdout, and stderr of the process, and wait
-for the process to complete.
+Subprocess is a single header cross-platform library that allows users to launch
+sub-processes, interact with the stdin, stdout, and stderr of the process, and
+wait for them to complete.
 
 ### Launching a Process
 
-To launch a process you call `process_create` like so:
+To launch a process you call `subprocess_create` like so:
 
 ```c
 const char *command_line[] = {"echo", "\"Hello, world!\"", NULL};
-struct process_s process;
-int result = process_create(command_line, 0, &process);
+struct subprocess_s subprocess;
+int result = subprocess_create(command_line, 0, &subprocess);
 if (0 != result) {
   // an error occurred!
 }
@@ -36,60 +36,61 @@ if (0 != result) {
 You specify an array of string for the command line - terminating the array with
 a `NULL` element.
 
-If the process is created successfully then 0 is returned from `process_create`.
+If the process is created successfully then 0 is returned from
+`subprocess_create`.
 
 ### Writing to the Standard Input of a Process
 
-To write to the standard input of a child process you call `process_stdin` to
+To write to the standard input of a child process you call `subprocess_stdin` to
 get the FILE handle to write with, passing a previously created process, like
 so:
 
 ```c
-FILE* p_stdin = process_stdin(&process);
+FILE* p_stdin = subprocess_stdin(&process);
 fputs("Hello, world!", p_stdin);
 ```
 
-Care must be taken to not write to the stdin after any call to `process_join` or
-`process_destroy`.
+Care must be taken to not write to the stdin after any call to `subprocess_join`
+or `subprocess_destroy`.
 
 ### Reading from the Standard Output of a Process
 
-To read from the standard output of a child process you call `process_stdout` to
-get the FILE handle to read with, passing a previously created process, like
+To read from the standard output of a child process you call `subprocess_stdout`
+to get the FILE handle to read with, passing a previously created process, like
 so:
 
 ```c
-FILE* p_stdout = process_stdout(&process);
+FILE* p_stdout = subprocess_stdout(&process);
 char hello_world[32];
 fgets(hello_world, 32, p_stdout);
 ```
 
 Care must be taken to not read from the stdout after any call to 
-`process_destroy`.
+`subprocess_destroy`.
 
 ### Reading from the Standard Error of a Process
 
-To read from the standard error of a child process you call `process_stderr` to
-get the FILE handle to read with, passing a previously created process, like
+To read from the standard error of a child process you call `subprocess_stderr`
+to get the FILE handle to read with, passing a previously created process, like
 so:
 
 ```c
-FILE* p_stderr = process_stderr(&process);
+FILE* p_stderr = subprocess_stderr(&process);
 char hello_world[32];
 fgets(hello_world, 32, p_stderr);
 ```
 
 Care must be taken to not read from the stderr after any call to 
-`process_destroy`.
+`subprocess_destroy`.
 
 ### Waiting on a Process
 
 To wait for a previously created process to finish executing you call
-`process_join` like so:
+`subprocess_join` like so:
 
 ```c
 int process_return;
-int result = process_join(&process, &process_return);
+int result = subprocess_join(&process, &process_return);
 if (0 != result) {
   // an error occurred!
 }
@@ -101,10 +102,10 @@ don't care about the process' return code.
 
 ### Destroying a Process
 
-To destroy a previously created process you call `process_destroy` like so:
+To destroy a previously created process you call `subprocess_destroy` like so:
 
 ```c
-int result = process_destroy(&process);
+int result = subprocess_destroy(&process);
 if (0 != result) {
   // an error occurred!
 }
@@ -118,7 +119,7 @@ process for instance.
 
 The current list of todos:
 
-* Add the ability to [set environment variables of the child process](https://github.com/sheredom/process.h/issues/1)
+* Add the ability to [set environment variables of the child process](https://github.com/sheredom/subprocess.h/issues/1)
   as suggested by [@graphitemaster](https://github.com/graphitemaster).
 * Add the ability to specify if a child process should die if the parent process
   is terminated.

--- a/subprocess.h
+++ b/subprocess.h
@@ -1,6 +1,6 @@
 /*
    The latest version of this library is available on GitHub;
-   https://github.com/sheredom/process.h
+   https://github.com/sheredom/subprocess.h
 */
 
 /*
@@ -30,8 +30,8 @@
    For more information, please refer to <http://unlicense.org/>
 */
 
-#ifndef SHEREDOM_PROCESS_H_INCLUDED
-#define SHEREDOM_PROCESS_H_INCLUDED
+#ifndef SHEREDOM_SUBPROCESS_H_INCLUDED
+#define SHEREDOM_SUBPROCESS_H_INCLUDED
 
 #if defined(_MSC_VER)
 #pragma warning(push, 1)
@@ -44,23 +44,23 @@
 #endif
 
 #if defined(__clang__) || defined(__GNUC__)
-#define process_pure __attribute__((pure))
-#define process_weak __attribute__((weak))
+#define subprocess_pure __attribute__((pure))
+#define subprocess_weak __attribute__((weak))
 #elif defined(_MSC_VER)
-#define process_pure
-#define process_weak __inline
+#define subprocess_pure
+#define subprocess_weak __inline
 #else
 #error Non clang, non gcc, non MSVC compiler found!
 #endif
 
-struct process_s;
+struct subprocess_s;
 
-enum process_option_e {
+enum subprocess_option_e {
   // stdout and stderr are the same FILE.
-  process_option_combined_stdout_stderr = 0x1,
+  subprocess_option_combined_stdout_stderr = 0x1,
 
   // The child process should inherit the environment variables of the parent.
-  process_option_inherit_environment = 0x2
+  subprocess_option_inherit_environment = 0x2
 };
 
 #if defined(__cplusplus)
@@ -70,11 +70,12 @@ extern "C" {
 /// @brief Create a process.
 /// @param command_line An array of strings for the command line to execute for
 /// this process. The last element must be NULL to signify the end of the array.
-/// @param options A bit field of process_option_e's to pass.
+/// @param options A bit field of subprocess_option_e's to pass.
 /// @param out_process The newly created process.
 /// @return On success 0 is returned.
-process_weak int process_create(const char *const command_line[], int options,
-                                struct process_s *const out_process);
+subprocess_weak int subprocess_create(const char *const command_line[],
+                                      int options,
+                                      struct subprocess_s *const out_process);
 
 /// @brief Get the standard input file for a process.
 /// @param process The process to query.
@@ -82,8 +83,8 @@ process_weak int process_create(const char *const command_line[], int options,
 ///
 /// The file returned can be written to by the parent process to feed data to
 /// the standard input of the process.
-process_pure process_weak FILE *
-process_stdin(const struct process_s *const process);
+subprocess_pure subprocess_weak FILE *
+subprocess_stdin(const struct subprocess_s *const process);
 
 /// @brief Get the standard output file for a process.
 /// @param process The process to query.
@@ -91,8 +92,8 @@ process_stdin(const struct process_s *const process);
 ///
 /// The file returned can be read from by the parent process to read data from
 /// the standard output of the child process.
-process_pure process_weak FILE *
-process_stdout(const struct process_s *const process);
+subprocess_pure subprocess_weak FILE *
+subprocess_stdout(const struct subprocess_s *const process);
 
 /// @brief Get the standard error file for a process.
 /// @param process The process to query.
@@ -101,11 +102,11 @@ process_stdout(const struct process_s *const process);
 /// The file returned can be read from by the parent process to read data from
 /// the standard error of the child process.
 ///
-/// If the process was created with the process_option_combined_stdout_stderr
-/// option bit set, this function will return NULL, and the process_stdout
+/// If the process was created with the subprocess_option_combined_stdout_stderr
+/// option bit set, this function will return NULL, and the subprocess_stdout
 /// function should be used for both the standard output and error combined.
-process_pure process_weak FILE *
-process_stderr(const struct process_s *const process);
+subprocess_pure subprocess_weak FILE *
+subprocess_stderr(const struct subprocess_s *const process);
 
 /// @brief Wait for a process to finish execution.
 /// @param process The process to wait for.
@@ -114,15 +115,15 @@ process_stderr(const struct process_s *const process);
 /// @return On success 0 is returned.
 ///
 /// Joining a process will close the stdin pipe to the process.
-process_weak int process_join(struct process_s *const process,
-                              int *const out_return_code);
+subprocess_weak int subprocess_join(struct subprocess_s *const process,
+                                    int *const out_return_code);
 
 /// @brief Destroy a previously created process.
 /// @param process The process to destroy.
 ///
 /// If the process to be destroyed had not finished execution, it may out live
 /// the parent process.
-process_weak int process_destroy(struct process_s *const process);
+subprocess_weak int subprocess_destroy(struct subprocess_s *const process);
 
 #if defined(__cplusplus)
 } // extern "C"
@@ -149,20 +150,20 @@ typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
 typedef struct _STARTUPINFOA *LPSTARTUPINFOA;
 
 #pragma warning(push, 1)
-struct process_process_information_s {
+struct subprocess_subprocess_information_s {
   void *hProcess;
   void *hThread;
   unsigned long dwProcessId;
   unsigned long dwThreadId;
 };
 
-struct process_security_attributes_s {
+struct subprocess_security_attributes_s {
   unsigned long nLength;
   void *lpSecurityDescriptor;
   int bInheritHandle;
 };
 
-struct process_startup_info_s {
+struct subprocess_startup_info_s {
   unsigned long cb;
   char *lpReserved;
   char *lpDesktop;
@@ -205,7 +206,7 @@ void *__cdecl _alloca(size_t);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
-struct process_s {
+struct subprocess_s {
   FILE *stdin_file;
   FILE *stdout_file;
   FILE *stderr_file;
@@ -223,8 +224,8 @@ struct process_s {
 #pragma clang diagnostic pop
 #endif
 
-int process_create(const char *const commandLine[], int options,
-                   struct process_s *const out_process) {
+int subprocess_create(const char *const commandLine[], int options,
+                      struct subprocess_s *const out_process) {
 #if defined(_MSC_VER)
   int fd;
   void *rd, *wr;
@@ -233,17 +234,17 @@ int process_create(const char *const commandLine[], int options,
   int i, j;
   const unsigned long startFUseStdHandles = 0x00000100;
   const unsigned long handleFlagInherit = 0x00000001;
-  struct process_process_information_s processInfo;
-  struct process_security_attributes_s saAttr = {sizeof(saAttr), 0, 1};
+  struct subprocess_subprocess_information_s processInfo;
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr), 0, 1};
   char *environment = 0;
-  struct process_startup_info_s startInfo = {0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                             0, 0, 0, 0, 0, 0, 0, 0, 0};
+  struct subprocess_startup_info_s startInfo = {0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   startInfo.cb = sizeof(startInfo);
   startInfo.dwFlags = startFUseStdHandles;
 
-  if (process_option_inherit_environment !=
-      (options & process_option_inherit_environment)) {
+  if (subprocess_option_inherit_environment !=
+      (options & subprocess_option_inherit_environment)) {
     environment = "\0\0";
   }
 
@@ -287,8 +288,8 @@ int process_create(const char *const commandLine[], int options,
 
   startInfo.hStdOutput = wr;
 
-  if (process_option_combined_stdout_stderr ==
-      (options & process_option_combined_stdout_stderr)) {
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
     out_process->stderr_file = out_process->stdout_file;
     startInfo.hStdError = startInfo.hStdOutput;
   } else {
@@ -382,8 +383,8 @@ int process_create(const char *const commandLine[], int options,
     return -1;
   }
 
-  if (process_option_combined_stdout_stderr !=
-      (options & process_option_combined_stdout_stderr)) {
+  if (subprocess_option_combined_stdout_stderr !=
+      (options & subprocess_option_combined_stdout_stderr)) {
     if (0 != pipe(stderrfd)) {
       return -1;
     }
@@ -406,8 +407,8 @@ int process_create(const char *const commandLine[], int options,
     // Map the write end to stdout
     dup2(stdoutfd[1], STDOUT_FILENO);
 
-    if (process_option_combined_stdout_stderr ==
-        (options & process_option_combined_stdout_stderr)) {
+    if (subprocess_option_combined_stdout_stderr ==
+        (options & subprocess_option_combined_stdout_stderr)) {
       dup2(STDOUT_FILENO, STDERR_FILENO);
     } else {
       // Close the stderr read end
@@ -421,8 +422,8 @@ int process_create(const char *const commandLine[], int options,
 #pragma clang diagnostic ignored "-Wcast-qual"
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #endif
-    if (process_option_inherit_environment !=
-        (options & process_option_inherit_environment)) {
+    if (subprocess_option_inherit_environment !=
+        (options & subprocess_option_inherit_environment)) {
       char *const environment[1] = {0};
       exit(execve(commandLine[0], (char *const *)commandLine, environment));
     } else {
@@ -442,8 +443,8 @@ int process_create(const char *const commandLine[], int options,
     // Store the stdout read end
     out_process->stdout_file = fdopen(stdoutfd[0], "rb");
 
-    if (process_option_combined_stdout_stderr ==
-        (options & process_option_combined_stdout_stderr)) {
+    if (subprocess_option_combined_stdout_stderr ==
+        (options & subprocess_option_combined_stdout_stderr)) {
       out_process->stderr_file = out_process->stdout_file;
     } else {
       // Close the stderr write end
@@ -460,15 +461,15 @@ int process_create(const char *const commandLine[], int options,
 #endif
 }
 
-FILE *process_stdin(const struct process_s *const process) {
+FILE *subprocess_stdin(const struct subprocess_s *const process) {
   return process->stdin_file;
 }
 
-FILE *process_stdout(const struct process_s *const process) {
+FILE *subprocess_stdout(const struct subprocess_s *const process) {
   return process->stdout_file;
 }
 
-FILE *process_stderr(const struct process_s *const process) {
+FILE *subprocess_stderr(const struct subprocess_s *const process) {
   if (process->stdout_file != process->stderr_file) {
     return process->stderr_file;
   } else {
@@ -476,7 +477,8 @@ FILE *process_stderr(const struct process_s *const process) {
   }
 }
 
-int process_join(struct process_s *const process, int *const out_return_code) {
+int subprocess_join(struct subprocess_s *const process,
+                    int *const out_return_code) {
 #if defined(_MSC_VER)
   const unsigned long infinite = 0xFFFFFFFF;
 
@@ -535,7 +537,7 @@ int process_join(struct process_s *const process, int *const out_return_code) {
 #endif
 }
 
-int process_destroy(struct process_s *const process) {
+int subprocess_destroy(struct subprocess_s *const process) {
   if (0 != process->stdin_file) {
     fclose(process->stdin_file);
   }
@@ -569,4 +571,4 @@ int process_destroy(struct process_s *const process) {
   return 0;
 }
 
-#endif /* SHEREDOM_PROCESS_H_INCLUDED */
+#endif /* SHEREDOM_SUBPROCESS_H_INCLUDED */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,7 +42,7 @@ add_executable(process_combined_stdout_stderr process_combined_stdout_stderr.c)
 add_executable(process_inherit_environment process_inherit_environment.c)
 
 add_executable(process_test
-  ../process.h
+  ../subprocess.h
   utest.h
   main.c
   test.c

--- a/test/main.c
+++ b/test/main.c
@@ -25,74 +25,74 @@
 
 #include "utest.h"
 
-#include "process.h"
+#include "subprocess.h"
 
-UTEST(create, process_return_zero) {
+UTEST(create, subprocess_return_zero) {
   const char *const commandLine[] = {"./process_return_zero", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_return_fortytwo) {
+UTEST(create, subprocess_return_fortytwo) {
   const char *const commandLine[] = {"./process_return_fortytwo", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(42, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_return_argc) {
-  const char *const commandLine[] = {"./process_return_argc", "foo",
-                                     "bar", "baz", "faz", 0};
-  struct process_s process;
+UTEST(create, subprocess_return_argc) {
+  const char *const commandLine[] = {
+      "./process_return_argc", "foo", "bar", "baz", "faz", 0};
+  struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(5, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_return_argv) {
+UTEST(create, subprocess_return_argv) {
   const char *const commandLine[] = {"./process_return_argv", "13", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(13, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_return_stdin) {
+UTEST(create, subprocess_return_stdin) {
   const char *const commandLine[] = {"./process_return_stdin", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stdin_file;
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  stdin_file = process_stdin(&process);
+  stdin_file = subprocess_stdin(&process);
   ASSERT_TRUE(stdin_file);
 
   ASSERT_EQ('a', putc('a', stdin_file));
@@ -111,74 +111,74 @@ UTEST(create, process_return_stdin) {
   ASSERT_EQ('t', putc('t', stdin_file));
   ASSERT_EQ('!', putc('!', stdin_file));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_return_stdin_count) {
+UTEST(create, subprocess_return_stdin_count) {
   const char *const commandLine[] = {"./process_return_stdin_count", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stdin_file;
   const char temp[41] = "Wee, sleekit, cow'rin, tim'rous beastie!";
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  stdin_file = process_stdin(&process);
+  stdin_file = subprocess_stdin(&process);
   ASSERT_TRUE(stdin_file);
 
   ASSERT_NE(EOF, fputs(temp, stdin_file));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(40, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_stdout_argc) {
+UTEST(create, subprocess_stdout_argc) {
   const char *const commandLine[] = {
       "./process_stdout_argc", "foo", "bar", "baz", "faz", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stdout_file;
   char temp[32];
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  stdout_file = process_stdout(&process);
+  stdout_file = subprocess_stdout(&process);
   ASSERT_TRUE(stdout_file);
 
   ASSERT_TRUE(fgets(temp, 32, stdout_file));
 
   ASSERT_EQ(5, atoi(temp));
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_stdout_argv) {
+UTEST(create, subprocess_stdout_argv) {
   const char *const commandLine[] = {
       "./process_stdout_argv", "foo", "bar", "baz", "faz", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stdout_file;
   char temp[16];
   const char compare[16] = "foo bar baz faz";
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  stdout_file = process_stdout(&process);
+  stdout_file = subprocess_stdout(&process);
   ASSERT_TRUE(stdout_file);
 
   ASSERT_TRUE(fgets(temp, 16, stdout_file));
@@ -189,49 +189,49 @@ UTEST(create, process_stdout_argv) {
   ASSERT_FALSE(fgets(temp, 16, stdout_file)); // should be at EOF now
   ASSERT_TRUE(feof(stdout_file));
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_stderr_argc) {
+UTEST(create, subprocess_stderr_argc) {
   const char *const commandLine[] = {
       "./process_stderr_argc", "foo", "bar", "baz", "faz", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stderr_file;
   char temp[32];
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  stderr_file = process_stderr(&process);
+  stderr_file = subprocess_stderr(&process);
   ASSERT_TRUE(stderr_file);
 
   ASSERT_TRUE(fgets(temp, 32, stderr_file));
 
   ASSERT_EQ(5, atoi(temp));
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_stderr_argv) {
+UTEST(create, subprocess_stderr_argv) {
   const char *const commandLine[] = {
       "./process_stderr_argv", "foo", "bar", "baz", "faz", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stderr_file;
   char temp[16];
   const char compare[16] = "foo bar baz faz";
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  stderr_file = process_stderr(&process);
+  stderr_file = subprocess_stderr(&process);
   ASSERT_TRUE(stderr_file);
 
   ASSERT_TRUE(fgets(temp, 16, stderr_file));
@@ -242,41 +242,42 @@ UTEST(create, process_stderr_argv) {
   ASSERT_FALSE(fgets(temp, 16, stderr_file)); // should be at EOF now
   ASSERT_TRUE(feof(stderr_file));
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_combined_stdout_stderr) {
+UTEST(create, subprocess_combined_stdout_stderr) {
   const char *const commandLine[] = {"./process_combined_stdout_stderr", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
   FILE *stdout_file;
   FILE *stderr_file;
   char temp[25];
   const char compare[25] = "Hello,It's me!world!Yay!";
 
-  ASSERT_EQ(0, process_create(commandLine,
-                              process_option_combined_stdout_stderr, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine,
+                                 subprocess_option_combined_stdout_stderr,
+                                 &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  stdout_file = process_stdout(&process);
+  stdout_file = subprocess_stdout(&process);
   ASSERT_TRUE(stdout_file);
 
-  stderr_file = process_stderr(&process);
+  stderr_file = subprocess_stderr(&process);
   ASSERT_FALSE(stderr_file);
 
   ASSERT_TRUE(fgets(temp, 25, stdout_file));
 
   ASSERT_STREQ(compare, temp);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_not_inherit_environment) {
+UTEST(create, subprocess_not_inherit_environment) {
   const char *const commandLine[] = {"./process_inherit_environment", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
 #ifdef _MSC_VER
@@ -285,18 +286,18 @@ UTEST(create, process_not_inherit_environment) {
   ASSERT_FALSE(putenv("PROCESS_ENV_TEST=1"));
 #endif
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_inherit_environment) {
+UTEST(create, subprocess_inherit_environment) {
   const char *const commandLine[] = {"./process_inherit_environment", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
 #ifdef _MSC_VER
@@ -305,19 +306,20 @@ UTEST(create, process_inherit_environment) {
   ASSERT_FALSE(putenv("PROCESS_ENV_TEST=42"));
 #endif
 
-  ASSERT_EQ(0, process_create(commandLine, process_option_inherit_environment,
-                              &process));
+  ASSERT_EQ(0,
+            subprocess_create(commandLine,
+                              subprocess_option_inherit_environment, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(42, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_not_inherit_all_environment) {
+UTEST(create, subprocess_not_inherit_all_environment) {
   const char *const commandLine[] = {"./process_inherit_environment", "all", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
 #ifdef _MSC_VER
@@ -326,18 +328,18 @@ UTEST(create, process_not_inherit_all_environment) {
   ASSERT_FALSE(putenv("PROCESS_ENV_TEST=42"));
 #endif
 
-  ASSERT_EQ(0, process_create(commandLine, 0, &process));
+  ASSERT_EQ(0, subprocess_create(commandLine, 0, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(0, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
-UTEST(create, process_inherit_all_environment) {
+UTEST(create, subprocess_inherit_all_environment) {
   const char *const commandLine[] = {"./process_inherit_environment", "all", 0};
-  struct process_s process;
+  struct subprocess_s process;
   int ret = -1;
 
 #ifdef _MSC_VER
@@ -346,14 +348,15 @@ UTEST(create, process_inherit_all_environment) {
   ASSERT_FALSE(putenv("PROCESS_ENV_TEST=42"));
 #endif
 
-  ASSERT_EQ(0, process_create(commandLine, process_option_inherit_environment,
-                              &process));
+  ASSERT_EQ(0,
+            subprocess_create(commandLine,
+                              subprocess_option_inherit_environment, &process));
 
-  ASSERT_EQ(0, process_join(&process, &ret));
+  ASSERT_EQ(0, subprocess_join(&process, &ret));
 
   ASSERT_EQ(1, ret);
 
-  ASSERT_EQ(0, process_destroy(&process));
+  ASSERT_EQ(0, subprocess_destroy(&process));
 }
 
 UTEST_MAIN()

--- a/test/test.c
+++ b/test/test.c
@@ -25,4 +25,4 @@
    For more information, please refer to <http://unlicense.org/>
 */
 
-#include "process.h"
+#include "subprocess.h"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -23,4 +23,4 @@
 //
 // For more information, please refer to <http://unlicense.org/>
 
-#include "process.h"
+#include "subprocess.h"


### PR DESCRIPTION
Because Windows already has a header process.h so I've finally (3 years later) decided to just rename the header to subprocess.h as a get out clause.

Fixes #4.